### PR TITLE
refactor(sql): route relation planners through root

### DIFF
--- a/datafusion-examples/Cargo.toml
+++ b/datafusion-examples/Cargo.toml
@@ -52,6 +52,18 @@ path = "examples/external_dependency/dataframe-to-s3.rs"
 name = "query_aws_s3"
 path = "examples/external_dependency/query-aws-s3.rs"
 
+[[example]]
+name = "relation_planner_basic"
+path = "examples/relation_planner/basic.rs"
+
+[[example]]
+name = "relation_planner_chain"
+path = "examples/relation_planner/chain.rs"
+
+[[example]]
+name = "relation_planner_match_recognize"
+path = "examples/relation_planner/match_recognize.rs"
+
 [dev-dependencies]
 arrow = { workspace = true }
 # arrow_schema is required for record_batch! macro :sad:

--- a/datafusion-examples/examples/relation_planner/basic.rs
+++ b/datafusion-examples/examples/relation_planner/basic.rs
@@ -1,0 +1,98 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+use std::sync::Arc;
+
+use arrow::array::Int64Array;
+use arrow::datatypes::{DataType, Field, Schema};
+use arrow::record_batch::RecordBatch;
+use datafusion::common::{DataFusionError, Result};
+use datafusion::datasource::{MemTable, TableProvider};
+use datafusion::execution::context::{
+    SessionContext, SessionRelationPlanner, SessionSqlToRel,
+};
+use datafusion::logical_expr::{lit, LogicalPlan, LogicalPlanBuilder};
+use datafusion::sql::parser::DFParser;
+use datafusion::sql::planner::PlannerContext;
+use datafusion::sql::sqlparser::ast::TableFactor;
+
+struct SyntheticNumbersPlanner;
+
+impl SessionRelationPlanner for SyntheticNumbersPlanner {
+    fn plan_relation<'sql, 'state>(
+        &self,
+        relation: &TableFactor,
+        _sql_to_rel: &SessionSqlToRel<'sql, 'state>,
+        _planner_context: &mut PlannerContext,
+    ) -> Result<Option<LogicalPlan>> {
+        if let TableFactor::Table { name, .. } = relation {
+            if name.to_string() == "synthetic_numbers" {
+                let rows = vec![vec![lit(1_i64)], vec![lit(2_i64)], vec![lit(3_i64)]];
+                let plan = LogicalPlanBuilder::values(rows)?.build()?;
+                return Ok(Some(plan));
+            }
+        }
+
+        Ok(None)
+    }
+}
+
+fn build_numbers_table() -> Result<Arc<dyn TableProvider>> {
+    let schema = Arc::new(Schema::new(vec![Field::new(
+        "value",
+        DataType::Int64,
+        false,
+    )]));
+    let batch = RecordBatch::try_new(
+        schema.clone(),
+        vec![Arc::new(Int64Array::from(vec![10_i64, 20, 30]))],
+    )?;
+    MemTable::try_new(schema, vec![vec![batch]])
+        .map(|table| Arc::new(table) as Arc<dyn TableProvider>)
+}
+
+async fn plan_sql(session: &SessionContext, sql: &str) -> Result<LogicalPlan> {
+    let mut statements = DFParser::parse_sql(sql)?;
+    let statement = statements.pop_front().ok_or_else(|| {
+        DataFusionError::Plan(format!("SQL string contained no statements: {sql}"))
+    })?;
+    session.state().statement_to_plan(statement).await
+}
+
+#[tokio::main]
+async fn main() -> Result<()> {
+    let table = build_numbers_table()?;
+
+    let session = SessionContext::new();
+    session.register_table("numbers", Arc::clone(&table))?;
+    session.register_relation_planner(Arc::new(SyntheticNumbersPlanner));
+
+    let synthetic_plan =
+        plan_sql(&session, "SELECT * FROM synthetic_numbers AS s").await?;
+    println!(
+        "Synthetic relation planned by extension:\n{}\n",
+        synthetic_plan.display_indent()
+    );
+
+    let default_plan = plan_sql(&session, "SELECT * FROM numbers").await?;
+    println!(
+        "Fallback to default planner for regular table:\n{}\n",
+        default_plan.display_indent()
+    );
+
+    Ok(())
+}

--- a/datafusion-examples/examples/relation_planner/chain.rs
+++ b/datafusion-examples/examples/relation_planner/chain.rs
@@ -1,0 +1,169 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+use std::sync::Arc;
+
+use arrow::array::Int64Array;
+use arrow::datatypes::{DataType, Field, Schema};
+use arrow::record_batch::RecordBatch;
+use datafusion::common::{DataFusionError, Result};
+use datafusion::datasource::{MemTable, TableProvider};
+use datafusion::execution::context::{
+    SessionContext, SessionRelationPlanner, SessionSqlToRel,
+};
+use datafusion::logical_expr::{lit, LogicalPlan, LogicalPlanBuilder};
+use datafusion::sql::parser::DFParser;
+use datafusion::sql::planner::PlannerContext;
+use datafusion::sql::sqlparser::ast::{Ident, ObjectName, TableFactor};
+
+struct LimitWrapperPlanner {
+    fetch: usize,
+}
+
+impl SessionRelationPlanner for LimitWrapperPlanner {
+    fn plan_relation<'sql, 'state>(
+        &self,
+        relation: &TableFactor,
+        sql_to_rel: &SessionSqlToRel<'sql, 'state>,
+        planner_context: &mut PlannerContext,
+    ) -> Result<Option<LogicalPlan>> {
+        if let TableFactor::Table { name, .. } = relation {
+            let ident = name.to_string();
+            if let Some(base) = ident.strip_prefix("limit_") {
+                let mut nested = relation.clone();
+                if let TableFactor::Table { name, .. } = &mut nested {
+                    *name = ObjectName(vec![Ident::new(base)]);
+                }
+                let plan = sql_to_rel.plan_table_factor(nested, planner_context)?;
+                let limited = LogicalPlanBuilder::from(plan)
+                    .limit(0, Some(self.fetch))?
+                    .build()?;
+                return Ok(Some(limited));
+            }
+        }
+
+        Ok(None)
+    }
+}
+
+struct SeriesPlanner;
+
+impl SessionRelationPlanner for SeriesPlanner {
+    fn plan_relation<'sql, 'state>(
+        &self,
+        relation: &TableFactor,
+        _sql_to_rel: &SessionSqlToRel<'sql, 'state>,
+        _planner_context: &mut PlannerContext,
+    ) -> Result<Option<LogicalPlan>> {
+        if let TableFactor::Table { name, .. } = relation {
+            let ident = name.to_string();
+            if let Some(size) = ident.strip_prefix("series_") {
+                if let Ok(count) = size.parse::<usize>() {
+                    if count == 0 {
+                        return Ok(None);
+                    }
+                    let rows = (0..count)
+                        .map(|value| vec![lit(value as i64)])
+                        .collect::<Vec<_>>();
+                    let plan = LogicalPlanBuilder::values(rows)?.build()?;
+                    return Ok(Some(plan));
+                }
+            }
+        }
+
+        Ok(None)
+    }
+}
+
+struct DistinctPlanner;
+
+impl SessionRelationPlanner for DistinctPlanner {
+    fn plan_relation<'sql, 'state>(
+        &self,
+        relation: &TableFactor,
+        sql_to_rel: &SessionSqlToRel<'sql, 'state>,
+        planner_context: &mut PlannerContext,
+    ) -> Result<Option<LogicalPlan>> {
+        if let TableFactor::Table { name, .. } = relation {
+            if let Some(base) = name.to_string().strip_suffix("_dedup") {
+                let mut nested = relation.clone();
+                if let TableFactor::Table { name, .. } = &mut nested {
+                    *name = ObjectName(vec![Ident::new(base)]);
+                }
+                let plan = sql_to_rel.plan_table_factor(nested, planner_context)?;
+                let deduped = LogicalPlanBuilder::from(plan).distinct()?.build()?;
+                return Ok(Some(deduped));
+            }
+        }
+
+        Ok(None)
+    }
+}
+
+fn build_numbers_table() -> Result<Arc<dyn TableProvider>> {
+    let schema = Arc::new(Schema::new(vec![Field::new(
+        "value",
+        DataType::Int64,
+        false,
+    )]));
+    let batch = RecordBatch::try_new(
+        schema.clone(),
+        vec![Arc::new(Int64Array::from(vec![1_i64, 2, 2, 3, 3, 4]))],
+    )?;
+    MemTable::try_new(schema, vec![vec![batch]])
+        .map(|table| Arc::new(table) as Arc<dyn TableProvider>)
+}
+
+async fn plan_sql(session: &SessionContext, sql: &str) -> Result<LogicalPlan> {
+    let mut statements = DFParser::parse_sql(sql)?;
+    let statement = statements.pop_front().ok_or_else(|| {
+        DataFusionError::Plan(format!("SQL string contained no statements: {sql}"))
+    })?;
+    session.state().statement_to_plan(statement).await
+}
+
+#[tokio::main]
+async fn main() -> Result<()> {
+    let numbers_table = build_numbers_table()?;
+
+    let session = SessionContext::new();
+    session.register_table("numbers", numbers_table)?;
+
+    session.register_relation_planner(Arc::new(LimitWrapperPlanner { fetch: 2 }));
+    session.register_relation_planner(Arc::new(DistinctPlanner));
+    session.register_relation_planner(Arc::new(SeriesPlanner));
+
+    let examples = [
+        ("Synthetic series", "SELECT * FROM series_5 AS s"),
+        (
+            "Limit wrapper rewrites",
+            "SELECT * FROM limit_numbers AS limited",
+        ),
+        (
+            "Distinct table rewrites",
+            "SELECT * FROM numbers_dedup AS deduped",
+        ),
+        ("Default table fallback", "SELECT * FROM numbers"),
+    ];
+
+    for (label, sql) in examples {
+        let plan = plan_sql(&session, sql).await?;
+        println!("{label}:\n{}\n", plan.display_indent());
+    }
+
+    Ok(())
+}

--- a/datafusion-examples/examples/relation_planner/match_recognize.rs
+++ b/datafusion-examples/examples/relation_planner/match_recognize.rs
@@ -1,0 +1,223 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+use std::fmt;
+use std::sync::Arc;
+
+use arrow::array::Int64Array;
+use arrow::datatypes::{DataType, Field, Schema};
+use arrow::record_batch::RecordBatch;
+use datafusion::common::{DFSchemaRef, DataFusionError, Result};
+use datafusion::datasource::{MemTable, TableProvider};
+use datafusion::execution::context::{
+    SessionContext, SessionRelationPlanner, SessionSqlToRel,
+};
+use datafusion::logical_expr::logical_plan::Extension;
+use datafusion::logical_expr::{Expr, LogicalPlan, UserDefinedLogicalNodeCore};
+use datafusion::sql::parser::DFParser;
+use datafusion::sql::planner::PlannerContext;
+use datafusion::sql::sqlparser::ast::TableFactor;
+
+/// Captures a minimal logical node that represents a planned MATCH_RECOGNIZE relation.
+#[derive(Debug, Clone, PartialEq, Eq, Hash, PartialOrd)]
+struct MatchRecognizeNode {
+    input: LogicalPlan,
+    partition_by: Vec<String>,
+    order_by: Vec<String>,
+    measures: Vec<String>,
+    rows_per_match: Option<String>,
+    after_match_skip: Option<String>,
+    pattern: String,
+    definitions: Vec<String>,
+}
+
+impl MatchRecognizeNode {
+    fn new(
+        input: LogicalPlan,
+        partition_by: Vec<String>,
+        order_by: Vec<String>,
+        measures: Vec<String>,
+        rows_per_match: Option<String>,
+        after_match_skip: Option<String>,
+        pattern: String,
+        definitions: Vec<String>,
+    ) -> Self {
+        Self {
+            input,
+            partition_by,
+            order_by,
+            measures,
+            rows_per_match,
+            after_match_skip,
+            pattern,
+            definitions,
+        }
+    }
+}
+
+impl UserDefinedLogicalNodeCore for MatchRecognizeNode {
+    fn name(&self) -> &str {
+        "MatchRecognizeNode"
+    }
+
+    fn inputs(&self) -> Vec<&LogicalPlan> {
+        vec![&self.input]
+    }
+
+    fn schema(&self) -> &DFSchemaRef {
+        self.input.schema()
+    }
+
+    fn expressions(&self) -> Vec<Expr> {
+        Vec::new()
+    }
+
+    fn fmt_for_explain(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let format_list = |values: &[String]| values.join(", ");
+        write!(
+            f,
+            "MatchRecognize(pattern={}, partition_by=[{}], order_by=[{}], measures=[{}]",
+            self.pattern,
+            format_list(&self.partition_by),
+            format_list(&self.order_by),
+            format_list(&self.measures)
+        )?;
+        if let Some(rows) = &self.rows_per_match {
+            write!(f, ", rows_per_match={rows}")?;
+        }
+        if let Some(skip) = &self.after_match_skip {
+            write!(f, ", {skip}")?;
+        }
+        if !self.definitions.is_empty() {
+            write!(f, ", define=[{}]", format_list(&self.definitions))?;
+        }
+        write!(f, ")")
+    }
+
+    fn with_exprs_and_inputs(
+        &self,
+        _exprs: Vec<Expr>,
+        mut inputs: Vec<LogicalPlan>,
+    ) -> Result<Self> {
+        let mut cloned = self.clone();
+        cloned.input = inputs
+            .pop()
+            .expect("MATCH_RECOGNIZE nodes expect a single input plan");
+        Ok(cloned)
+    }
+}
+
+struct MatchRecognizePlanner;
+
+impl SessionRelationPlanner for MatchRecognizePlanner {
+    fn plan_relation<'sql, 'state>(
+        &self,
+        relation: &TableFactor,
+        sql_to_rel: &SessionSqlToRel<'sql, 'state>,
+        planner_context: &mut PlannerContext,
+    ) -> Result<Option<LogicalPlan>> {
+        if let TableFactor::MatchRecognize {
+            table,
+            partition_by,
+            order_by,
+            measures,
+            rows_per_match,
+            after_match_skip,
+            pattern,
+            symbols,
+            ..
+        } = relation
+        {
+            let input =
+                sql_to_rel.plan_table_factor((**table).clone(), planner_context)?;
+            let node = MatchRecognizeNode::new(
+                input,
+                partition_by.iter().map(ToString::to_string).collect(),
+                order_by.iter().map(ToString::to_string).collect(),
+                measures.iter().map(ToString::to_string).collect(),
+                rows_per_match.as_ref().map(ToString::to_string),
+                after_match_skip.as_ref().map(ToString::to_string),
+                pattern.to_string(),
+                symbols.iter().map(ToString::to_string).collect(),
+            );
+            let plan = LogicalPlan::Extension(Extension {
+                node: Arc::new(node),
+            });
+            Ok(Some(plan))
+        } else {
+            Ok(None)
+        }
+    }
+}
+
+fn build_numbers_table() -> Result<Arc<dyn TableProvider>> {
+    let schema = Arc::new(Schema::new(vec![Field::new(
+        "value",
+        DataType::Int64,
+        false,
+    )]));
+    let batch = RecordBatch::try_new(
+        schema.clone(),
+        vec![Arc::new(Int64Array::from(vec![1_i64, 2, 3, 4]))],
+    )?;
+    MemTable::try_new(schema, vec![vec![batch]])
+        .map(|table| Arc::new(table) as Arc<dyn TableProvider>)
+}
+
+async fn plan_sql(session: &SessionContext, sql: &str) -> Result<LogicalPlan> {
+    let mut statements = DFParser::parse_sql(sql)?;
+    let statement = statements.pop_front().ok_or_else(|| {
+        DataFusionError::Plan(format!("SQL string contained no statements: {sql}"))
+    })?;
+    session.state().statement_to_plan(statement).await
+}
+
+#[tokio::main]
+async fn main() -> Result<()> {
+    let table = build_numbers_table()?;
+
+    let session = SessionContext::new();
+    session.register_table("numbers", table)?;
+    session.register_relation_planner(Arc::new(MatchRecognizePlanner));
+
+    let match_recognize_sql = r#"
+        SELECT *
+        FROM numbers MATCH_RECOGNIZE (
+            PARTITION BY value
+            ORDER BY value
+            MEASURES
+                MATCH_NUMBER() AS match_num
+            PATTERN (A+)
+            DEFINE
+                A AS value > 0
+        ) AS mr
+    "#;
+
+    let plan = plan_sql(&session, match_recognize_sql).await?;
+    println!(
+        "MATCH_RECOGNIZE relation planned via extension:\n{}\n",
+        plan.display_indent()
+    );
+
+    let fallback_plan = plan_sql(&session, "SELECT * FROM numbers").await?;
+    println!(
+        "Fallback to default planner for base table:\n{}\n",
+        fallback_plan.display_indent()
+    );
+
+    Ok(())
+}

--- a/datafusion/core/src/execution/context/mod.rs
+++ b/datafusion/core/src/execution/context/mod.rs
@@ -54,7 +54,9 @@ use crate::{
 };
 
 // backwards compatibility
-pub use crate::execution::session_state::SessionState;
+pub use crate::execution::session_state::{
+    SessionRelationPlanner, SessionSqlToRel, SessionState,
+};
 
 use arrow::datatypes::{Schema, SchemaRef};
 use arrow::record_batch::RecordBatch;
@@ -462,6 +464,11 @@ impl SessionContext {
     ) -> Self {
         self.state.write().set_function_factory(function_factory);
         self
+    }
+
+    /// Registers a relation planner that participates in SQL planning for this session.
+    pub fn register_relation_planner(&self, planner: Arc<dyn SessionRelationPlanner>) {
+        self.state.write().register_relation_planner(planner);
     }
 
     /// Adds an optimizer rule to the end of the existing rules.

--- a/datafusion/core/src/execution/session_state.rs
+++ b/datafusion/core/src/execution/session_state.rs
@@ -70,14 +70,16 @@ use datafusion_physical_optimizer::PhysicalOptimizerRule;
 use datafusion_physical_plan::ExecutionPlan;
 use datafusion_session::Session;
 use datafusion_sql::parser::{DFParserBuilder, Statement};
-use datafusion_sql::planner::{ContextProvider, ParserOptions, PlannerContext, SqlToRel};
+use datafusion_sql::planner::{
+    ContextProvider, ParserOptions, PlannerContext, RelationPlanner, SqlToRel,
+};
 
 use async_trait::async_trait;
 use chrono::{DateTime, Utc};
 use itertools::Itertools;
 use log::{debug, info};
 use object_store::ObjectStore;
-use sqlparser::ast::{Expr as SQLExpr, ExprWithAlias as SQLExprWithAlias};
+use sqlparser::ast::{Expr as SQLExpr, ExprWithAlias as SQLExprWithAlias, TableFactor};
 use sqlparser::dialect::dialect_from_str;
 use url::Url;
 use uuid::Uuid;
@@ -123,6 +125,58 @@ use uuid::Uuid;
 /// [`SessionContext`].
 ///
 /// [`SessionContext`]: crate::execution::context::SessionContext
+pub type SessionSqlToRel<'sql, 'state> = SqlToRel<'sql, SessionContextProvider<'state>>;
+
+/// Custom relation planner registered against a [`SessionContext`].
+pub trait SessionRelationPlanner: Send + Sync {
+    /// Attempt to plan `relation`. Returning `Ok(Some(plan))` short-circuits the
+    /// planner chain, while `Ok(None)` defers to later planners or the default
+    /// SQL planner.
+    fn plan_relation<'sql, 'state>(
+        &self,
+        relation: &TableFactor,
+        sql_to_rel: &SessionSqlToRel<'sql, 'state>,
+        planner_context: &mut PlannerContext,
+    ) -> datafusion_common::Result<Option<LogicalPlan>>;
+}
+
+#[derive(Clone)]
+struct RegisteredRelationPlanner {
+    inner: Arc<dyn SessionRelationPlanner>,
+}
+
+impl RegisteredRelationPlanner {
+    fn new(inner: Arc<dyn SessionRelationPlanner>) -> Self {
+        Self { inner }
+    }
+}
+
+impl<'state> RelationPlanner<SessionContextProvider<'state>>
+    for RegisteredRelationPlanner
+{
+    fn plan_relation(
+        &self,
+        relation: &TableFactor,
+        sql_to_rel: &SqlToRel<'_, SessionContextProvider<'state>>,
+        planner_context: &mut PlannerContext,
+    ) -> datafusion_common::Result<Option<LogicalPlan>> {
+        self.inner
+            .plan_relation(relation, sql_to_rel, planner_context)
+    }
+}
+
+fn session_relation_planners_to_sql<'a>(
+    planners: &[Arc<dyn SessionRelationPlanner>],
+) -> Vec<Arc<dyn RelationPlanner<SessionContextProvider<'a>> + Send + Sync>> {
+    planners
+        .iter()
+        .map(|planner| {
+            Arc::new(RegisteredRelationPlanner::new(Arc::clone(planner)))
+                as Arc<dyn RelationPlanner<SessionContextProvider<'a>> + Send + Sync>
+        })
+        .collect()
+}
+
 #[derive(Clone)]
 pub struct SessionState {
     /// A unique UUID that identifies the session
@@ -176,6 +230,9 @@ pub struct SessionState {
     /// It will be invoked on `CREATE FUNCTION` statements.
     /// thus, changing dialect o PostgreSql is required
     function_factory: Option<Arc<dyn FunctionFactory>>,
+    /// Collection of registered relation planners used while converting SQL
+    /// statements into logical plans.
+    relation_planners: Vec<Arc<dyn SessionRelationPlanner>>,
     /// Cache logical plans of prepared statements for later execution.
     /// Key is the prepared statement name.
     prepared_plans: HashMap<String, Arc<PreparedPlan>>,
@@ -206,6 +263,7 @@ impl Debug for SessionState {
             .field("scalar_functions", &self.scalar_functions)
             .field("aggregate_functions", &self.aggregate_functions)
             .field("window_functions", &self.window_functions)
+            .field("relation_planners", &self.relation_planners.len())
             .field("prepared_plans", &self.prepared_plans)
             .finish()
     }
@@ -457,6 +515,27 @@ impl SessionState {
         Ok(table_refs)
     }
 
+    /// Returns the registered relation planners for this session.
+    pub fn relation_planners(&self) -> &[Arc<dyn SessionRelationPlanner>] {
+        &self.relation_planners
+    }
+
+    /// Replaces the registered relation planners for this session.
+    pub fn set_relation_planners(
+        &mut self,
+        relation_planners: Vec<Arc<dyn SessionRelationPlanner>>,
+    ) {
+        self.relation_planners = relation_planners;
+    }
+
+    /// Registers an additional relation planner for this session.
+    pub fn register_relation_planner(
+        &mut self,
+        planner: Arc<dyn SessionRelationPlanner>,
+    ) {
+        self.relation_planners.push(planner);
+    }
+
     /// Convert an AST Statement into a LogicalPlan
     pub async fn statement_to_plan(
         &self,
@@ -481,7 +560,9 @@ impl SessionState {
             }
         }
 
-        let query = SqlToRel::new_with_options(&provider, self.get_parser_options());
+        let relation_planners = session_relation_planners_to_sql(&self.relation_planners);
+        let query = SqlToRel::new_with_options(&provider, self.get_parser_options())
+            .with_relation_planners(relation_planners);
         query.statement_to_plan(statement)
     }
 
@@ -910,6 +991,7 @@ pub struct SessionStateBuilder {
     table_factories: Option<HashMap<String, Arc<dyn TableProviderFactory>>>,
     runtime_env: Option<Arc<RuntimeEnv>>,
     function_factory: Option<Arc<dyn FunctionFactory>>,
+    relation_planners: Option<Vec<Arc<dyn SessionRelationPlanner>>>,
     // fields to support convenience functions
     analyzer_rules: Option<Vec<Arc<dyn AnalyzerRule + Send + Sync>>>,
     optimizer_rules: Option<Vec<Arc<dyn OptimizerRule + Send + Sync>>>,
@@ -946,6 +1028,7 @@ impl SessionStateBuilder {
             table_factories: None,
             runtime_env: None,
             function_factory: None,
+            relation_planners: None,
             // fields to support convenience functions
             analyzer_rules: None,
             optimizer_rules: None,
@@ -997,6 +1080,7 @@ impl SessionStateBuilder {
             table_factories: Some(existing.table_factories),
             runtime_env: Some(existing.runtime_env),
             function_factory: existing.function_factory,
+            relation_planners: Some(existing.relation_planners),
 
             // fields to support convenience functions
             analyzer_rules: None,
@@ -1064,6 +1148,29 @@ impl SessionStateBuilder {
     /// Set the session id.
     pub fn with_session_id(mut self, session_id: String) -> Self {
         self.session_id = Some(session_id);
+        self
+    }
+
+    /// Registers an additional relation planner that will run before the
+    /// default SQL planning implementation.
+    pub fn with_relation_planner(
+        mut self,
+        relation_planner: Arc<dyn SessionRelationPlanner>,
+    ) -> Self {
+        self.relation_planners
+            .get_or_insert_with(Vec::new)
+            .push(relation_planner);
+        self
+    }
+
+    /// Extends the session with additional relation planners.
+    pub fn with_relation_planners(
+        mut self,
+        relation_planners: Vec<Arc<dyn SessionRelationPlanner>>,
+    ) -> Self {
+        self.relation_planners
+            .get_or_insert_with(Vec::new)
+            .extend(relation_planners);
         self
     }
 
@@ -1347,6 +1454,7 @@ impl SessionStateBuilder {
             table_factories,
             runtime_env,
             function_factory,
+            relation_planners,
             analyzer_rules,
             optimizer_rules,
             physical_optimizer_rules,
@@ -1382,6 +1490,7 @@ impl SessionStateBuilder {
             table_factories: table_factories.unwrap_or_default(),
             runtime_env,
             function_factory,
+            relation_planners: relation_planners.unwrap_or_default(),
             prepared_plans: HashMap::new(),
         };
 
@@ -1635,7 +1744,7 @@ impl From<SessionState> for SessionStateBuilder {
 ///
 /// This is used so the SQL planner can access the state of the session without
 /// having a direct dependency on the [`SessionState`] struct (and core crate)
-struct SessionContextProvider<'a> {
+pub struct SessionContextProvider<'a> {
     state: &'a SessionState,
     tables: HashMap<ResolvedTableReference, Arc<dyn TableSource>>,
 }

--- a/datafusion/core/tests/sql/sql_api.rs
+++ b/datafusion/core/tests/sql/sql_api.rs
@@ -170,6 +170,81 @@ async fn empty_statement_returns_error() {
 }
 
 #[tokio::test]
+async fn session_relation_planner_registration() -> datafusion::error::Result<()> {
+    use arrow::array::Int64Array;
+    use arrow::datatypes::{DataType, Field, Schema};
+    use arrow::record_batch::RecordBatch;
+    use datafusion::common::Result;
+    use datafusion::datasource::MemTable;
+    use datafusion::execution::context::{SessionRelationPlanner, SessionSqlToRel};
+    use datafusion::logical_expr::{lit, LogicalPlan, LogicalPlanBuilder};
+    use datafusion::sql::parser::DFParser;
+    use datafusion::sql::planner::PlannerContext;
+    use datafusion::sql::sqlparser::ast::TableFactor;
+    use std::sync::Arc;
+
+    struct SyntheticPlanner;
+
+    impl SessionRelationPlanner for SyntheticPlanner {
+        fn plan_relation<'sql, 'state>(
+            &self,
+            relation: &TableFactor,
+            _sql_to_rel: &SessionSqlToRel<'sql, 'state>,
+            _planner_context: &mut PlannerContext,
+        ) -> Result<Option<LogicalPlan>> {
+            if let TableFactor::Table { name, .. } = relation {
+                if name.to_string() == "synthetic" {
+                    let plan =
+                        LogicalPlanBuilder::values(vec![vec![lit(42_i64)]])?.build()?;
+                    return Ok(Some(plan));
+                }
+            }
+
+            Ok(None)
+        }
+    }
+
+    async fn plan_sql(ctx: &SessionContext, sql: &str) -> Result<LogicalPlan> {
+        let mut statements = DFParser::parse_sql(sql)?;
+        let statement = statements.pop_front().ok_or_else(|| {
+            datafusion::common::DataFusionError::Plan(format!(
+                "SQL string contained no statements: {sql}"
+            ))
+        })?;
+        ctx.state().statement_to_plan(statement).await
+    }
+
+    let ctx = SessionContext::new();
+    ctx.register_relation_planner(Arc::new(SyntheticPlanner));
+
+    let schema = Arc::new(Schema::new(vec![Field::new(
+        "value",
+        DataType::Int64,
+        false,
+    )]));
+    let batch = RecordBatch::try_new(
+        schema.clone(),
+        vec![Arc::new(Int64Array::from(vec![1_i64, 2, 3]))],
+    )?;
+    let table = MemTable::try_new(schema, vec![vec![batch]])?;
+    ctx.register_table("numbers", Arc::new(table))?;
+
+    let synthetic_plan = plan_sql(&ctx, "SELECT * FROM synthetic").await?;
+    assert!(synthetic_plan
+        .display_indent()
+        .to_string()
+        .contains("Values"));
+
+    let fallback_plan = plan_sql(&ctx, "SELECT * FROM numbers").await?;
+    assert!(fallback_plan
+        .display_indent()
+        .to_string()
+        .contains("TableScan"));
+
+    Ok(())
+}
+
+#[tokio::test]
 async fn multiple_statements_returns_error() {
     let ctx = SessionContext::new();
     ctx.sql("CREATE TABLE test (x int)").await.unwrap();

--- a/datafusion/sql/src/planner.rs
+++ b/datafusion/sql/src/planner.rs
@@ -39,6 +39,9 @@ use sqlparser::ast::{DataType as SQLDataType, Ident, ObjectName, TableAlias};
 use crate::utils::make_decimal_type;
 pub use datafusion_expr::planner::ContextProvider;
 
+pub use crate::relation::RelationPlanner;
+use sqlparser::ast::TableFactor;
+
 /// SQL parser options
 #[derive(Debug, Clone, Copy)]
 pub struct ParserOptions {
@@ -337,6 +340,7 @@ pub struct SqlToRel<'a, S: ContextProvider> {
     pub(crate) context_provider: &'a S,
     pub(crate) options: ParserOptions,
     pub(crate) ident_normalizer: IdentNormalizer,
+    relation_planners: Vec<Arc<dyn RelationPlanner<S> + Send + Sync>>,
 }
 
 impl<'a, S: ContextProvider> SqlToRel<'a, S> {
@@ -359,7 +363,22 @@ impl<'a, S: ContextProvider> SqlToRel<'a, S> {
             context_provider,
             options,
             ident_normalizer: IdentNormalizer::new(ident_normalize),
+            relation_planners: vec![],
         }
+    }
+
+    /// Replace the relation planners used by this [`SqlToRel`].
+    pub fn with_relation_planners(
+        mut self,
+        relation_planners: Vec<Arc<dyn RelationPlanner<S> + Send + Sync>>,
+    ) -> Self {
+        self.relation_planners = relation_planners;
+        self
+    }
+
+    /// Returns the registered relation planners.
+    pub fn relation_planners(&self) -> &[Arc<dyn RelationPlanner<S> + Send + Sync>] {
+        &self.relation_planners
     }
 
     pub fn build_schema(&self, columns: Vec<SQLColumnDef>) -> Result<Schema> {

--- a/datafusion/sql/src/relation/mod.rs
+++ b/datafusion/sql/src/relation/mod.rs
@@ -26,33 +26,102 @@ use datafusion_common::{
 use datafusion_expr::builder::subquery_alias;
 use datafusion_expr::{expr::Unnest, Expr, LogicalPlan, LogicalPlanBuilder};
 use datafusion_expr::{Subquery, SubqueryAlias};
-use sqlparser::ast::{FunctionArg, FunctionArgExpr, Spanned, TableFactor};
+use sqlparser::ast::{FunctionArg, FunctionArgExpr, Spanned, TableAlias, TableFactor};
 
 mod join;
 
+/// Allows external code to intercept the planning of specific [`TableFactor`]
+/// nodes while [`SqlToRel`] is building a [`LogicalPlan`].
+pub trait RelationPlanner<S: ContextProvider>: Send + Sync {
+    /// Attempt to produce a plan for `relation`.
+    ///
+    /// Returning `Ok(Some(plan))` short-circuits the planner chain and uses the
+    /// returned plan. Returning `Ok(None)` defers to the next registered planner
+    /// (or the default `SqlToRel` implementation when the chain is exhausted).
+    fn plan_relation(
+        &self,
+        relation: &TableFactor,
+        sql_to_rel: &SqlToRel<'_, S>,
+        planner_context: &mut PlannerContext,
+    ) -> Result<Option<LogicalPlan>>;
+}
+
 impl<S: ContextProvider> SqlToRel<'_, S> {
+    /// Create a `LogicalPlan` that scans the named relation
     /// Create a `LogicalPlan` that scans the named relation
     fn create_relation(
         &self,
         relation: TableFactor,
         planner_context: &mut PlannerContext,
     ) -> Result<LogicalPlan> {
+        self.plan_relation_with_extensions(&relation, planner_context)
+    }
+
+    /// Public entry point for extension authors to plan a [`TableFactor`]
+    /// using the currently registered relation planners.
+    ///
+    /// This method always restarts planning from the beginning of the planner
+    /// chain, ensuring nested relations see the same custom planners as
+    /// top-level relations.
+    pub fn plan_table_factor(
+        &self,
+        relation: TableFactor,
+        planner_context: &mut PlannerContext,
+    ) -> Result<LogicalPlan> {
+        self.create_relation(relation, planner_context)
+    }
+
+    fn plan_relation_with_extensions(
+        &self,
+        relation: &TableFactor,
+        planner_context: &mut PlannerContext,
+    ) -> Result<LogicalPlan> {
+        let alias = relation_alias(relation);
+        let plan = self.plan_relation_chain(relation, planner_context, 0)?;
+
+        let optimized_plan = optimize_subquery_sort(plan)?.data;
+        if let Some(alias) = alias {
+            self.apply_table_alias(optimized_plan, alias)
+        } else {
+            Ok(optimized_plan)
+        }
+    }
+
+    fn plan_relation_chain(
+        &self,
+        relation: &TableFactor,
+        planner_context: &mut PlannerContext,
+        index: usize,
+    ) -> Result<LogicalPlan> {
+        if let Some(planner) = self.relation_planners().get(index) {
+            if let Some(plan) = planner.plan_relation(relation, self, planner_context)? {
+                return Ok(plan);
+            }
+            return self.plan_relation_chain(relation, planner_context, index + 1);
+        }
+
+        self.create_relation_default(relation, planner_context)
+    }
+
+    fn create_relation_default(
+        &self,
+        relation: &TableFactor,
+        planner_context: &mut PlannerContext,
+    ) -> Result<LogicalPlan> {
         let relation_span = relation.span();
-        let (plan, alias) = match relation {
-            TableFactor::Table {
-                name, alias, args, ..
-            } => {
+        let plan = match relation {
+            TableFactor::Table { name, args, .. } => {
                 if let Some(func_args) = args {
                     let tbl_func_name =
                         name.0.first().unwrap().as_ident().unwrap().to_string();
                     let args = func_args
                         .args
-                        .into_iter()
+                        .iter()
                         .flat_map(|arg| {
                             if let FunctionArg::Unnamed(FunctionArgExpr::Expr(expr)) = arg
                             {
                                 self.sql_expr_to_logical_expr(
-                                    expr,
+                                    expr.clone(),
                                     &DFSchema::empty(),
                                     planner_context,
                                 )
@@ -64,78 +133,65 @@ impl<S: ContextProvider> SqlToRel<'_, S> {
                     let provider = self
                         .context_provider
                         .get_table_function_source(&tbl_func_name, args)?;
-                    let plan = LogicalPlanBuilder::scan(
+                    LogicalPlanBuilder::scan(
                         TableReference::Bare {
                             table: format!("{tbl_func_name}()").into(),
                         },
                         provider,
                         None,
                     )?
-                    .build()?;
-                    (plan, alias)
+                    .build()?
                 } else {
-                    // Normalize name and alias
+                    let name = name.clone();
                     let table_ref = self.object_name_to_table_reference(name)?;
                     let table_name = table_ref.to_string();
                     let cte = planner_context.get_cte(&table_name);
-                    (
-                        match (
-                            cte,
-                            self.context_provider.get_table_source(table_ref.clone()),
-                        ) {
-                            (Some(cte_plan), _) => Ok(cte_plan.clone()),
-                            (_, Ok(provider)) => LogicalPlanBuilder::scan(
-                                table_ref.clone(),
-                                provider,
-                                None,
-                            )?
-                            .build(),
-                            (None, Err(e)) => {
-                                let e = e.with_diagnostic(Diagnostic::new_error(
-                                    format!("table '{table_ref}' not found"),
-                                    Span::try_from_sqlparser_span(relation_span),
-                                ));
-                                Err(e)
-                            }
-                        }?,
-                        alias,
-                    )
+                    match (
+                        cte,
+                        self.context_provider.get_table_source(table_ref.clone()),
+                    ) {
+                        (Some(cte_plan), _) => Ok(cte_plan.clone()),
+                        (_, Ok(provider)) => {
+                            LogicalPlanBuilder::scan(table_ref.clone(), provider, None)?
+                                .build()
+                        }
+                        (None, Err(e)) => {
+                            let e = e.with_diagnostic(Diagnostic::new_error(
+                                format!("table '{table_ref}' not found"),
+                                Span::try_from_sqlparser_span(relation_span),
+                            ));
+                            Err(e)
+                        }
+                    }?
                 }
             }
-            TableFactor::Derived {
-                subquery, alias, ..
-            } => {
-                let logical_plan = self.query_to_plan(*subquery, planner_context)?;
-                (logical_plan, alias)
+            TableFactor::Derived { subquery, .. } => {
+                let subquery = *subquery.clone();
+                self.query_to_plan(subquery, planner_context)?
             }
             TableFactor::NestedJoin {
-                table_with_joins,
-                alias,
-            } => (
-                self.plan_table_with_joins(*table_with_joins, planner_context)?,
-                alias,
-            ),
+                table_with_joins, ..
+            } => {
+                self.plan_table_with_joins(*table_with_joins.clone(), planner_context)?
+            }
             TableFactor::UNNEST {
-                alias,
                 array_exprs,
                 with_offset: false,
                 with_offset_alias: None,
                 with_ordinality,
+                ..
             } => {
-                if with_ordinality {
+                if *with_ordinality {
                     return not_impl_err!("UNNEST with ordinality is not supported yet");
                 }
 
-                // Unnest table factor has empty input
                 let schema = DFSchema::empty();
                 let input = LogicalPlanBuilder::empty(true).build()?;
-                // Unnest table factor can have multiple arguments.
-                // We treat each argument as a separate unnest expression.
                 let unnest_exprs = array_exprs
-                    .into_iter()
+                    .iter()
                     .map(|sql_expr| {
                         let expr = self.sql_expr_to_logical_expr(
-                            sql_expr,
+                            sql_expr.clone(),
                             &schema,
                             planner_context,
                         )?;
@@ -146,44 +202,39 @@ impl<S: ContextProvider> SqlToRel<'_, S> {
                 if unnest_exprs.is_empty() {
                     return plan_err!("UNNEST must have at least one argument");
                 }
-                let logical_plan = self.try_process_unnest(input, unnest_exprs)?;
-                (logical_plan, alias)
+                self.try_process_unnest(input, unnest_exprs)?
             }
             TableFactor::UNNEST { .. } => {
                 return not_impl_err!(
                     "UNNEST table factor with offset is not supported yet"
                 );
             }
-            TableFactor::Function {
-                name, args, alias, ..
-            } => {
-                let tbl_func_ref = self.object_name_to_table_reference(name)?;
+            TableFactor::Function { name, args, .. } => {
+                let tbl_func_ref = self.object_name_to_table_reference(name.clone())?;
                 let schema = planner_context
                     .outer_query_schema()
                     .cloned()
                     .unwrap_or_else(DFSchema::empty);
                 let func_args = args
-                    .into_iter()
+                    .iter()
                     .map(|arg| match arg {
                         FunctionArg::Unnamed(FunctionArgExpr::Expr(expr))
                         | FunctionArg::Named {
                             arg: FunctionArgExpr::Expr(expr),
                             ..
-                        } => {
-                            self.sql_expr_to_logical_expr(expr, &schema, planner_context)
-                        }
+                        } => self.sql_expr_to_logical_expr(
+                            expr.clone(),
+                            &schema,
+                            planner_context,
+                        ),
                         _ => plan_err!("Unsupported function argument: {arg:?}"),
                     })
                     .collect::<Result<Vec<Expr>>>()?;
                 let provider = self
                     .context_provider
                     .get_table_function_source(tbl_func_ref.table(), func_args)?;
-                let plan =
-                    LogicalPlanBuilder::scan(tbl_func_ref.table(), provider, None)?
-                        .build()?;
-                (plan, alias)
+                LogicalPlanBuilder::scan(tbl_func_ref.table(), provider, None)?.build()?
             }
-            // @todo Support TableFactory::TableFunction?
             _ => {
                 return not_impl_err!(
                     "Unsupported ast node {relation:?} in create_relation"
@@ -191,14 +242,8 @@ impl<S: ContextProvider> SqlToRel<'_, S> {
             }
         };
 
-        let optimized_plan = optimize_subquery_sort(plan)?.data;
-        if let Some(alias) = alias {
-            self.apply_table_alias(optimized_plan, alias)
-        } else {
-            Ok(optimized_plan)
-        }
+        Ok(plan)
     }
-
     pub(crate) fn create_relation_subquery(
         &self,
         subquery: TableFactor,
@@ -252,6 +297,17 @@ impl<S: ContextProvider> SqlToRel<'_, S> {
                 spans: Spans::new(),
             })),
         }
+    }
+}
+
+fn relation_alias(relation: &TableFactor) -> Option<TableAlias> {
+    match relation {
+        TableFactor::Table { alias, .. }
+        | TableFactor::Derived { alias, .. }
+        | TableFactor::NestedJoin { alias, .. }
+        | TableFactor::UNNEST { alias, .. }
+        | TableFactor::Function { alias, .. } => alias.clone(),
+        _ => None,
     }
 }
 

--- a/datafusion/sql/tests/sql_integration.rs
+++ b/datafusion/sql/tests/sql_integration.rs
@@ -22,16 +22,18 @@ use std::vec;
 
 use arrow::datatypes::{TimeUnit::Nanosecond, *};
 use common::MockContextProvider;
-use datafusion_common::{assert_contains, DataFusionError, Result};
+use datafusion_common::{assert_contains, DataFusionError, Result, ScalarValue};
 use datafusion_expr::{
-    col, logical_plan::LogicalPlan, test::function_stub::sum_udaf, ColumnarValue,
-    CreateIndex, DdlStatement, ScalarFunctionArgs, ScalarUDF, ScalarUDFImpl, Signature,
-    Volatility,
+    col,
+    logical_plan::{LogicalPlan, LogicalPlanBuilder},
+    test::function_stub::sum_udaf,
+    ColumnarValue, CreateIndex, DdlStatement, Expr, ScalarFunctionArgs, ScalarUDF,
+    ScalarUDFImpl, Signature, Volatility,
 };
 use datafusion_functions::{string, unicode};
 use datafusion_sql::{
     parser::DFParser,
-    planner::{ParserOptions, SqlToRel},
+    planner::{ParserOptions, PlannerContext, RelationPlanner, SqlToRel},
 };
 
 use crate::common::{CustomExprPlanner, CustomTypePlanner, MockSessionState};
@@ -45,6 +47,7 @@ use datafusion_functions_nested::make_array::make_array_udf;
 use datafusion_functions_window::rank::rank_udwf;
 use insta::{allow_duplicates, assert_snapshot};
 use rstest::rstest;
+use sqlparser::ast::{Ident, ObjectName, ObjectNamePart, TableFactor};
 use sqlparser::dialect::{Dialect, GenericDialect, HiveDialect, MySqlDialect};
 
 mod cases;
@@ -4713,4 +4716,239 @@ fn test_using_join_wildcard_schema() {
             "t3.d".to_string()
         ]
     );
+}
+
+struct OverrideTablePlanner;
+
+impl RelationPlanner<MockContextProvider> for OverrideTablePlanner {
+    fn plan_relation(
+        &self,
+        relation: &TableFactor,
+        _sql_to_rel: &SqlToRel<'_, MockContextProvider>,
+        _planner_context: &mut PlannerContext,
+    ) -> Result<Option<LogicalPlan>> {
+        if let TableFactor::Table { name, .. } = relation {
+            if name.to_string() == "ext_table" {
+                let plan = LogicalPlanBuilder::empty(true).build()?;
+                return Ok(Some(plan));
+            }
+        }
+        Ok(None)
+    }
+}
+
+struct DistinctPlanner;
+
+impl RelationPlanner<MockContextProvider> for DistinctPlanner {
+    fn plan_relation(
+        &self,
+        relation: &TableFactor,
+        sql_to_rel: &SqlToRel<'_, MockContextProvider>,
+        planner_context: &mut PlannerContext,
+    ) -> Result<Option<LogicalPlan>> {
+        if let TableFactor::Table { name, .. } = relation {
+            if let Some(base) = name.to_string().strip_suffix("_dedup") {
+                let mut nested = relation.clone();
+                if let TableFactor::Table { name, .. } = &mut nested {
+                    *name =
+                        ObjectName(vec![ObjectNamePart::Identifier(Ident::new(base))]);
+                }
+                let plan = sql_to_rel.plan_table_factor(nested, planner_context)?;
+                let plan = LogicalPlanBuilder::from(plan).distinct()?.build()?;
+                return Ok(Some(plan));
+            }
+        }
+        Ok(None)
+    }
+}
+
+struct LimitPlanner;
+
+impl RelationPlanner<MockContextProvider> for LimitPlanner {
+    fn plan_relation(
+        &self,
+        relation: &TableFactor,
+        sql_to_rel: &SqlToRel<'_, MockContextProvider>,
+        planner_context: &mut PlannerContext,
+    ) -> Result<Option<LogicalPlan>> {
+        if let TableFactor::Table { name, .. } = relation {
+            if let Some(base) = name.to_string().strip_prefix("limit_") {
+                let mut nested = relation.clone();
+                if let TableFactor::Table { name, .. } = &mut nested {
+                    *name =
+                        ObjectName(vec![ObjectNamePart::Identifier(Ident::new(base))]);
+                }
+                let plan = sql_to_rel.plan_table_factor(nested, planner_context)?;
+                let plan = LogicalPlanBuilder::from(plan).limit(0, Some(5))?.build()?;
+                return Ok(Some(plan));
+            }
+        }
+        Ok(None)
+    }
+}
+
+struct ProxyPlanner;
+
+impl RelationPlanner<MockContextProvider> for ProxyPlanner {
+    fn plan_relation(
+        &self,
+        relation: &TableFactor,
+        sql_to_rel: &SqlToRel<'_, MockContextProvider>,
+        planner_context: &mut PlannerContext,
+    ) -> Result<Option<LogicalPlan>> {
+        if let TableFactor::Table { name, .. } = relation {
+            if name.to_string() == "proxy" {
+                let mut nested_relation = relation.clone();
+                if let TableFactor::Table { name, .. } = &mut nested_relation {
+                    *name = ObjectName(vec![ObjectNamePart::Identifier(Ident::new(
+                        "person_dedup",
+                    ))]);
+                }
+                let plan =
+                    sql_to_rel.plan_table_factor(nested_relation, planner_context)?;
+                return Ok(Some(plan));
+            }
+        }
+        Ok(None)
+    }
+}
+
+#[test]
+fn relation_planner_override_relation() -> Result<()> {
+    let context = MockContextProvider {
+        state: MockSessionState::default(),
+    };
+    let planner = SqlToRel::new(&context)
+        .with_relation_planners(vec![Arc::new(OverrideTablePlanner)
+            as Arc<dyn RelationPlanner<MockContextProvider> + Send + Sync>]);
+    let statement = DFParser::parse_sql("SELECT * FROM ext_table AS alias")?
+        .into_iter()
+        .next()
+        .unwrap();
+    let plan = planner.statement_to_plan(statement)?;
+    if let LogicalPlan::Projection(projection) = plan {
+        match projection.input.as_ref() {
+            LogicalPlan::SubqueryAlias(alias_plan) => {
+                assert_eq!(alias_plan.alias.to_string(), "alias");
+                assert!(matches!(
+                    alias_plan.input.as_ref(),
+                    LogicalPlan::EmptyRelation(_)
+                ));
+            }
+            other => panic!("expected SubqueryAlias, got {:#?}", other),
+        }
+    } else {
+        panic!("expected projection plan");
+    }
+    Ok(())
+}
+
+#[test]
+fn relation_planner_chain_handles_rewrites() -> Result<()> {
+    let context = MockContextProvider {
+        state: MockSessionState::default(),
+    };
+    let planners: Vec<Arc<dyn RelationPlanner<MockContextProvider> + Send + Sync>> =
+        vec![Arc::new(DistinctPlanner)];
+    let planner = SqlToRel::new(&context).with_relation_planners(planners);
+    let statement = DFParser::parse_sql("SELECT * FROM person_dedup")?
+        .into_iter()
+        .next()
+        .unwrap();
+    let plan = planner.statement_to_plan(statement)?;
+    if let LogicalPlan::Projection(projection) = plan {
+        assert!(matches!(
+            projection.input.as_ref(),
+            LogicalPlan::Distinct(_)
+        ));
+    } else {
+        panic!("expected projection plan");
+    }
+    Ok(())
+}
+
+#[test]
+fn relation_planner_limit_rewrite() -> Result<()> {
+    let context = MockContextProvider {
+        state: MockSessionState::default(),
+    };
+    let planners: Vec<Arc<dyn RelationPlanner<MockContextProvider> + Send + Sync>> =
+        vec![Arc::new(LimitPlanner)];
+    let planner = SqlToRel::new(&context).with_relation_planners(planners);
+    let statement = DFParser::parse_sql("SELECT * FROM limit_orders")?
+        .into_iter()
+        .next()
+        .unwrap();
+    let plan = planner.statement_to_plan(statement)?;
+    if let LogicalPlan::Projection(projection) = plan {
+        match projection.input.as_ref() {
+            LogicalPlan::Limit(limit) => {
+                if let Some(expr) = &limit.fetch {
+                    match expr.as_ref() {
+                        Expr::Literal(ScalarValue::UInt64(Some(value)), _) => {
+                            assert_eq!(*value, 5);
+                        }
+                        Expr::Literal(ScalarValue::Int64(Some(value)), _) => {
+                            assert_eq!(*value, 5);
+                        }
+                        other => panic!("unexpected limit expression: {other:?}"),
+                    }
+                } else {
+                    panic!("limit missing fetch");
+                }
+            }
+            other => panic!("expected Limit, got {other:?}"),
+        }
+    } else {
+        panic!("expected projection plan");
+    }
+    Ok(())
+}
+
+#[test]
+fn relation_planner_falls_back_to_default() -> Result<()> {
+    let context = MockContextProvider {
+        state: MockSessionState::default(),
+    };
+    let planners: Vec<Arc<dyn RelationPlanner<MockContextProvider> + Send + Sync>> =
+        vec![Arc::new(LimitPlanner)];
+    let planner = SqlToRel::new(&context).with_relation_planners(planners);
+    let statement = DFParser::parse_sql("SELECT * FROM orders")?
+        .into_iter()
+        .next()
+        .unwrap();
+    let plan = planner.statement_to_plan(statement)?;
+    if let LogicalPlan::Projection(projection) = plan {
+        assert!(matches!(
+            projection.input.as_ref(),
+            LogicalPlan::TableScan(_)
+        ));
+    } else {
+        panic!("expected projection plan");
+    }
+    Ok(())
+}
+
+#[test]
+fn relation_planner_restart_chain_for_nested_plans() -> Result<()> {
+    let context = MockContextProvider {
+        state: MockSessionState::default(),
+    };
+    let planners: Vec<Arc<dyn RelationPlanner<MockContextProvider> + Send + Sync>> =
+        vec![Arc::new(ProxyPlanner), Arc::new(DistinctPlanner)];
+    let planner = SqlToRel::new(&context).with_relation_planners(planners);
+    let statement = DFParser::parse_sql("SELECT * FROM proxy")?
+        .into_iter()
+        .next()
+        .unwrap();
+    let plan = planner.statement_to_plan(statement)?;
+    if let LogicalPlan::Projection(projection) = plan {
+        assert!(matches!(
+            projection.input.as_ref(),
+            LogicalPlan::Distinct(_)
+        ));
+    } else {
+        panic!("expected projection plan");
+    }
+    Ok(())
 }


### PR DESCRIPTION
## Summary
- simplify `RelationPlanner` by removing the delegation context and always restarting planning from the root of the chain
- update the session-level relation planner adapter to the streamlined interface
- refresh the examples and SQL integration tests to exercise the root-only delegation pattern

## Testing
- cargo test -p datafusion-sql relation_planner *(fails: unable to download crates because the CONNECT tunnel returned 403)*
- cargo test -p datafusion session_relation_planner_registration *(fails: unable to download crates because the CONNECT tunnel returned 403)*

------
https://chatgpt.com/codex/tasks/task_b_68d77d5bb9dc8324968b6c7e7b1a3d79